### PR TITLE
add hash to bundle file, use webpack middleware in dev only

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "redux-form": "^4.0.5",
     "redux-simple-router": "^1.0.2",
     "redux-thunk": "^0.1.0",
-    "reselect": "^2.0.1"
+    "reselect": "^2.0.1",
+    "superagent": "^1.7.1"
   },
   "devDependencies": {
     "babel-core": "^5.6.18",
@@ -38,6 +39,7 @@
     "babel-plugin-react-transform": "^1.1.0",
     "expect": "^1.6.0",
     "express": "^4.13.3",
+    "html-webpack-plugin": "^2.7.1",
     "jsdom": "^5.6.1",
     "mocha": "^2.2.5",
     "node-libs-browser": "^0.5.2",

--- a/server.js
+++ b/server.js
@@ -1,24 +1,35 @@
-var webpack = require('webpack')
-var webpackDevMiddleware = require('webpack-dev-middleware')
-var webpackHotMiddleware = require('webpack-hot-middleware')
-var config = require('./webpack.config')
 var path = require('path');
+var request = require('superagent');
+
+var __DEV__ = process.env.NODE_ENV !== 'production';
 
 var app = new (require('express'))()
 var port = 3000
 
-var compiler = webpack(config)
-app.use(webpackDevMiddleware(compiler, { noInfo: true, publicPath: config.output.publicPath }))
-app.use(webpackHotMiddleware(compiler))
+if (__DEV__) {
+  var webpack = require('webpack')
+  var webpackDevMiddleware = require('webpack-dev-middleware')
+  var webpackHotMiddleware = require('webpack-hot-middleware')
+  var config = require('./webpack.config')
 
-app.get("/", function(req, res) {
-  res.sendFile(__dirname + '/index.html')
-})
+  var compiler = webpack(config)
+  app.use(webpackDevMiddleware(compiler, { noInfo: true, publicPath: config.output.publicPath }))
+  app.use(webpackHotMiddleware(compiler))
+}
 
 //keep this handler on the last position of the stack, it serves the index.html if reloading from any url.
-app.get('*', function (req, res){
-    res.sendFile(path.resolve(__dirname, 'index.html'))
-});
+if (__DEV__) {
+  app.get('*', function (req, res){
+    request.get('http://localhost:' + port + '/static/index.html')
+      .end(function(err, response) {
+        return err ? res.send(err) : res.send(response.text);
+      });
+  });
+} else {
+  app.get('*', function (req, res){
+    res.sendFile(path.resolve(__dirname, 'dist/index.html'))
+  });
+}
 
 app.listen(port, function(error) {
   if (error) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,8 +4,6 @@
     <title>Redux redradix example</title>
   </head>
   <body>
-    <div id="root">
-    </div>
-    <script src="/static/bundle.js"></script>
+    <div id="root"></div>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 var path = require('path')
 var webpack = require('webpack')
+var HtmlWebpackPlugin = require('html-webpack-plugin')
 
 module.exports = {
   devtool: 'cheap-module-eval-source-map',
@@ -8,14 +9,19 @@ module.exports = {
     './index'
   ],
   output: {
-    path: path.join(__dirname, 'dist'),
-    filename: 'bundle.js',
-    publicPath: '/static/'
+    path: path.join(__dirname, 'dist/js'),
+    filename: 'bundle.[hash:6].js',
+    publicPath: '/static/',
+    hash: true
   },
   plugins: [
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.NoErrorsPlugin(),
+    new HtmlWebpackPlugin({
+      template: 'templates/index.html',
+      filename: 'index.html'
+    })
   ],
   module: {
     loaders: [


### PR DESCRIPTION
A couple of changes here:

- Use Webpack middleware only in development
- Setup Webpack to append hash string to bundle file name, for cache busting. This will force browsers to reload the script.
- Server HTML page differently in development and production. For development it's using HtmlWebpackPlugin which allows inject builded scripts at build time. Useful when you have more than one output file or want to inject other stuff.